### PR TITLE
Modernize project to C++23 and replace Boost containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.20)
 
 #--------------------------------------------------------------------------------------------------#
 
-project (netcode)
+project (netcode LANGUAGES CXX)
 
 #--------------------------------------------------------------------------------------------------#
 
@@ -10,11 +10,9 @@ enable_testing()
 
 #--------------------------------------------------------------------------------------------------#
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if (NOT COMPILER_SUPPORTS_CXX11)
-  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
-endif ()
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 #--------------------------------------------------------------------------------------------------#
 
@@ -77,7 +75,7 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif ()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wconversion ${CMAKE_CXX_FLAGS}")
+add_compile_options(-Wall -Wextra -Wconversion)
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 ${CMAKE_CXX_FLAGS_DEBUG}")
 set(CMAKE_CXX_FLAGS_RELEASE "-fvisibility=hidden -fvisibility-inlines-hidden ${CMAKE_CXX_FLAGS_RELEASE}")
 

--- a/netcode/detail/buffer.hh
+++ b/netcode/detail/buffer.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include <boost/align/aligned_allocator.hpp>
@@ -13,41 +15,33 @@ namespace ntc { namespace detail {
 /// @brief Allocator to avoid value initialization
 /// @see http://stackoverflow.com/a/21028912/21584
 template <typename T, typename Alloc = std::allocator<T>>
-class default_init_allocator
-  : public Alloc
+class default_init_allocator : public Alloc
 {
 private:
-
-  using a_t = std::allocator_traits<Alloc>;
+  using base = Alloc;
+  using traits = std::allocator_traits<Alloc>;
 
 public:
-
-  /// @brief Constructor. Forward to base clase constructor
-  /// @note @code using Alloc::Alloc @endcode would be the right way to write it,
-  /// but GCC 4.7 doesn't support this feature.
-  template <typename... Args>
-  explicit default_init_allocator(Args&&... args)
-    : Alloc{std::forward<Args>(args)...}
-  {}
+  using base::base;
 
   template <typename U>
   struct rebind
   {
-    using other = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+    using other = default_init_allocator<U, typename traits::template rebind_alloc<U>>;
   };
 
   template <typename U>
   void
   construct(U* ptr)
   {
-    ::new (static_cast<void*>(ptr)) U;
+    std::construct_at(ptr);
   }
 
   template <typename U, typename...Args>
   void
   construct(U* ptr, Args&&... args)
   {
-    a_t::construct(static_cast<Alloc&>(*this), ptr, std::forward<Args>(args)...);
+    traits::construct(static_cast<base&>(*this), ptr, std::forward<Args>(args)...);
   }
 };
 

--- a/netcode/detail/decoder.cc
+++ b/netcode/detail/decoder.cc
@@ -1,5 +1,6 @@
 #include <algorithm>  // all_of
 #include <cassert>
+#include <iterator>
 #include <vector>
 
 #include "netcode/detail/decoder.hh"
@@ -56,7 +57,7 @@ decoder::operator()(decoder_repair&& incoming_r)
 {
   assert(not incoming_r.source_ids().empty());
 
-  const auto last_id_in_source_ids = *(incoming_r.source_ids().end() - 1);
+  const auto last_id_in_source_ids = *std::prev(incoming_r.source_ids().end());
   if (m_last_id and last_id_in_source_ids < *m_last_id)
   {
     // It's a repair that provide outdated informations, drop it.

--- a/netcode/detail/decoder.hh
+++ b/netcode/detail/decoder.hh
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
 #include <vector>
-
-#include <boost/container/flat_set.hpp>
-#include <boost/container/map.hpp>
-#include <boost/optional.hpp>
 
 #include "netcode/detail/galois_field.hh"
 #include "netcode/detail/repair.hh"
@@ -23,10 +25,10 @@ class decoder final
 public:
 
   /// @brief Type of an ordered container of repairs.
-  using repairs_set_type = boost::container::map<std::uint32_t, decoder_repair>;
+  using repairs_set_type = std::map<std::uint32_t, decoder_repair>;
 
   /// @brief Type of an ordered container of sources.
-  using sources_set_type = boost::container::map<std::uint32_t, decoder_source>;
+  using sources_set_type = std::map<std::uint32_t, decoder_source>;
 
 private:
 
@@ -45,12 +47,11 @@ private:
 public:
 
   /// @brief Type of a sorted container of repair iterators.
-  using repairs_iterators_type = boost::container::flat_set< repairs_set_type::iterator
-                                                           , cmp_repairs_iterator>;
+  using repairs_iterators_type = std::set<repairs_set_type::iterator, cmp_repairs_iterator>;
 
   /// @brief Type of an ordered container that associate missing sources to the repairs that
   /// contain them.
-  using missing_sources_type = boost::container::map<std::uint32_t, repairs_iterators_type>;
+  using missing_sources_type = std::map<std::uint32_t, repairs_iterators_type>;
 
 public:
 
@@ -154,7 +155,7 @@ private:
 
   /// @brief Maintains a list of sources which could not be given to callback when some older
   /// sources are still missing.
-  boost::container::map<std::uint32_t, const decoder_source*> m_ordered_sources;
+  std::map<std::uint32_t, const decoder_source*> m_ordered_sources;
 
   /// @brief The callback to call when a source has been decoded or received.
   const std::function<void(const decoder_source&)> m_callback;
@@ -168,7 +169,7 @@ private:
   /// @brief Remember the last source identifier.
   ///
   /// All sources with an identifier smaller than this value were received or decoded in the past.
-  boost::optional<std::uint32_t> m_last_id;
+  std::optional<std::uint32_t> m_last_id;
 
   /// @brief All sources that have not been yet received, but which are referenced by a repair.
   missing_sources_type m_missing_sources;

--- a/netcode/detail/galois_field.hh
+++ b/netcode/detail/galois_field.hh
@@ -107,8 +107,8 @@ public:
 
     if (m_w <= 8) // 4 or 8
     {
-      __attribute__((aligned(16))) std::uint16_t res;
-      __attribute__((aligned(16))) std::uint16_t size_ = size;
+      alignas(16) std::uint16_t res;
+      alignas(16) std::uint16_t size_ = size;
       multiply( reinterpret_cast<char*>(&size_), reinterpret_cast<char*>(&res)
               , sizeof(std::uint16_t), coeff);
       return res;

--- a/netcode/detail/invert_matrix.cc
+++ b/netcode/detail/invert_matrix.cc
@@ -6,7 +6,7 @@ namespace ntc { namespace detail {
 
 /*------------------------------------------------------------------------------------------------*/
 
-boost::optional<std::size_t>
+std::optional<std::size_t>
 invert(galois_field& gf, square_matrix& mat, square_matrix& inv)
 noexcept
 {
@@ -40,7 +40,7 @@ noexcept
       if (j == rows)
       {
         // Failure, matrix is not invertible.
-        return {j - 1};
+        return j - 1;
       }
 
       const auto row_start2 = j * cols;
@@ -123,7 +123,7 @@ noexcept
   }
 
   // Everything went OK.
-  return {};
+  return std::nullopt;
 }
 
 /*------------------------------------------------------------------------------------------------*/

--- a/netcode/detail/invert_matrix.hh
+++ b/netcode/detail/invert_matrix.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <boost/optional.hpp>
+#include <cstddef>
+#include <optional>
 
 #include "netcode/detail/galois_field.hh"
 #include "netcode/detail/square_matrix.hh"
@@ -16,7 +17,7 @@ namespace ntc { namespace detail {
 /// @related square_matrix
 /// @return A initialized optional value if inversion failed. In this case, the value is the column
 /// which made the inversion fail.
-boost::optional<std::size_t>
+std::optional<std::size_t>
 invert(galois_field& gf, square_matrix& mat, square_matrix& inv)
 noexcept;
 

--- a/netcode/detail/source_id_list.hh
+++ b/netcode/detail/source_id_list.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <boost/container/flat_set.hpp>
+#include <cstdint>
+#include <set>
 
 namespace ntc { namespace detail {
 
@@ -8,7 +9,7 @@ namespace ntc { namespace detail {
 
 /// @internal
 /// @brief A sorted list of source identifiers.
-using source_id_list = boost::container::flat_set<std::uint32_t>;
+using source_id_list = std::set<std::uint32_t>;
 
 /*------------------------------------------------------------------------------------------------*/
 

--- a/tests/netcode/detail/test_encoder.cc
+++ b/tests/netcode/detail/test_encoder.cc
@@ -1,4 +1,5 @@
 #include <algorithm> // equal
+#include <iterator>
 
 #include <catch.hpp>
 #include "tests/netcode/launch.hh"
@@ -34,11 +35,11 @@ TEST_CASE("Encoder: create repairs")
     // We need an encoder to fill the repair.
     detail::encoder{gf_size}(r0, sl);
     REQUIRE(r0.source_ids().size() == 5);
-    REQUIRE(*(r0.source_ids().begin() + 0) == 0);
-    REQUIRE(*(r0.source_ids().begin() + 1) == 1);
-    REQUIRE(*(r0.source_ids().begin() + 2) == 2);
-    REQUIRE(*(r0.source_ids().begin() + 3) == 3);
-    REQUIRE(*(r0.source_ids().begin() + 4) == 4);
+    REQUIRE(*r0.source_ids().begin() == 0);
+    REQUIRE(*std::next(r0.source_ids().begin(), 1) == 1);
+    REQUIRE(*std::next(r0.source_ids().begin(), 2) == 2);
+    REQUIRE(*std::next(r0.source_ids().begin(), 3) == 3);
+    REQUIRE(*std::next(r0.source_ids().begin(), 4) == 4);
   });
 }
 

--- a/tests/netcode/detail/test_invert_matrix.cc
+++ b/tests/netcode/detail/test_invert_matrix.cc
@@ -1,4 +1,3 @@
-#include <boost/optional/optional_io.hpp>
 #include <catch.hpp>
 
 #include "tests/netcode/launch.hh"

--- a/tests/netcode/test_reconstruction.cc
+++ b/tests/netcode/test_reconstruction.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <iterator>
 
 #include <catch.hpp>
 #include "tests/netcode/common.hh"
@@ -126,8 +127,8 @@ TEST_CASE("Encode two sources")
 
     // We need an encoder to fill the repair.
     detail::encoder{gf_size}(r0, sl);
-    REQUIRE(*(r0.source_ids().begin() + 0) == 0);
-    REQUIRE(*(r0.source_ids().begin() + 1) == 1);
+    REQUIRE(*r0.source_ids().begin() == 0);
+    REQUIRE(*std::next(r0.source_ids().begin()) == 1);
 
     SECTION("s0 is lost")
     {
@@ -207,14 +208,14 @@ TEST_CASE("Two sources lost")
     // Create first repair.
     detail::encoder{gf_size}(r0, sl);
     REQUIRE(r0.source_ids().size() == 2);
-    REQUIRE(*(r0.source_ids().begin() + 0) == 0);
-    REQUIRE(*(r0.source_ids().begin() + 1) == 1);
+    REQUIRE(*r0.source_ids().begin() == 0);
+    REQUIRE(*std::next(r0.source_ids().begin()) == 1);
 
     // Create second repair.
     detail::encoder{gf_size}(r1, sl);
     REQUIRE(r1.source_ids().size() == 2);
-    REQUIRE(*(r1.source_ids().begin() + 0) == 0);
-    REQUIRE(*(r1.source_ids().begin() + 1) == 1);
+    REQUIRE(*r1.source_ids().begin() == 0);
+    REQUIRE(*std::next(r1.source_ids().begin()) == 1);
 
     // Oops, s0 and s1 are lost, but not r0 and r1.
 


### PR DESCRIPTION
## Summary
- require C++23 in the top-level CMake configuration and drop legacy compiler checks
- replace Boost optional/maps with their standard counterparts and refresh supporting utilities
- adjust unit tests to reflect std::set iteration semantics and remove Boost-only includes

## Testing
- cmake -S . -B build *(fails: gf-complete headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c88406765c8329ae8781f1db9d1a02